### PR TITLE
Add capability check to get popup settings

### DIFF
--- a/languages/popup-glassmorphism.pot
+++ b/languages/popup-glassmorphism.pot
@@ -29,6 +29,10 @@ msgstr ""
 msgid "Paramètres sauvegardés avec succès !"
 msgstr ""
 
+#: popup-glassmorphism.php:243
+msgid "Accès refusé"
+msgstr ""
+
 #: templates/admin-page.php:8
 msgid "Configuration Pop-up Glassmorphism"
 msgstr ""

--- a/popup-glassmorphism.php
+++ b/popup-glassmorphism.php
@@ -238,7 +238,11 @@ class PopupGlassmorphism {
      */
     public function get_popup_settings() {
         check_ajax_referer('popup_glass_nonce', 'nonce');
-        
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( __( 'Accès refusé', 'popup-glassmorphism' ) );
+        }
+
         $settings = get_option('popup_glass_settings', $this->default_options);
         wp_send_json_success($settings);
     }


### PR DESCRIPTION
## Summary
- secure the `get_popup_settings()` AJAX handler
- update translation template with new string

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a439d8b08832b80dbfdf11379f9b2