### PR TITLE
Fix mobile text size override

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -154,16 +154,12 @@
     .popup-glass-content {
         padding: 30px 20px 20px;
     }
-    
+
     .popup-glass-title {
         font-size: 1.3em;
         margin-bottom: 15px;
     }
-    
-    .popup-glass-text {
-        font-size: 14px !important;
-    }
-    
+
     .popup-glass-close {
         width: 30px;
         height: 30px;
@@ -187,9 +183,6 @@
         font-size: 1.2em;
     }
     
-    .popup-glass-text {
-        font-size: 13px !important;
-    }
 }
 
 /* Accessibilité */


### PR DESCRIPTION
## Summary
- remove font-size overrides from `.popup-glass-text` in mobile breakpoints so the inline font-size from plugin settings takes effect

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7101cef8832babdddd4fd7d91b1d